### PR TITLE
Fix hash function of {set,bag}-comparator

### DIFF
--- a/sets/sets-impl.scm
+++ b/sets/sets-impl.scm
@@ -1266,7 +1266,7 @@
   (let* ((ht (sob-hash-table sob))
          (hash (comparator-hash-function (sob-comparator sob))))
     (sob-fold
-      (lambda (element result) (+ (hash element) (* result 33)))
+      (lambda (element result) (+ (hash element) result))
       5381
       sob)))
 

--- a/sets/sets-test.scm
+++ b/sets/sets-test.scm
@@ -239,8 +239,8 @@
   (test-assert (set-any? inexact? nums))
   (define sos
     (set set-comparator
-      (set eqv-comparator 1 2)
-      (set eqv-comparator 1 2)))
+      (set equal-comparator '(2 . 1) '(1 . 1) '(0 . 2) '(0 . 0))
+      (set equal-comparator '(2 . 1) '(1 . 1) '(0 . 0) '(0 . 2))))
   (test 1 (set-size sos))
 ) ; end sets/lowlevel
 


### PR DESCRIPTION
Hash value of set/bag must not rely on the visiting order of
hash-table-for-each (called via sob-fold).
