### PR TITLE
CHICKEN Packaging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,5 @@
 *~
+*.swp
+*.import.scm
+*.so
+salmonella.log

--- a/sets/comparators-shim.scm
+++ b/sets/comparators-shim.scm
@@ -1,0 +1,91 @@
+;;; Below are some default comparators provided by SRFI-114,
+;;; but not SRFI-128, which this SRFI has transitioned to
+;;; depend on. See the rationale for SRFI-128 as to why it is
+;;; preferred in usage compared to SRFI-114.
+
+;; Most if not all of this code is taken from SRFI-114
+
+(define exact inexact->exact)
+
+(define string-foldcase string-downcase)
+
+(define (make-comparison=/< = <)
+  (lambda (a b)
+    (cond
+      ((= a b) 0)
+      ((< a b) -1)
+      (else 1))))
+
+;; Comparison procedure for real numbers only
+(define (real-comparison a b)
+  (cond
+    ((< a b) -1)
+    ((> a b) 1)
+    (else 0)))
+
+;; Comparison procedure for non-real numbers.
+(define (complex-comparison a b)
+  (let ((real-result (real-comparison (real-part a) (real-part b))))
+    (if (= real-result 0)
+      (real-comparison (imag-part a) (imag-part b))
+      real-result)))
+
+(define (number-hash obj) (exact (abs obj)))
+
+(define number-comparator
+  (make-comparator number? = complex-comparison number-hash))
+
+(define char-comparison (make-comparison=/< char=? char<?))
+
+(define (char-hash obj) (abs (char->integer obj)))
+
+(define char-comparator
+  (make-comparator char? char=? char-comparison char-hash))
+
+;; Makes a hash function that works vectorwise
+(define limit (expt 2 20))
+
+(define (make-vectorwise-hash hash length ref)
+  (lambda (obj)
+    (let loop ((index (- (length obj) 1)) (result 5381))
+      (if (= index 0)
+        result
+        (let* ((prod (modulo (* result 33) limit))
+               (sum (modulo (+ prod (hash (ref obj index))) limit)))
+          (loop (- index 1) sum))))))
+
+(define string-hash
+  (make-vectorwise-hash char-hash string-length string-ref))
+
+(define string-comparison (make-comparison=/< string=? string<?))
+
+(define string-ci-comparison (make-comparison=/< string-ci=? string-ci<?))
+
+(define string-comparator
+  (make-comparator string? string=? string-comparison string-hash))
+
+(define (string-ci-hash obj) (string-hash (string-foldcase obj)))
+
+(define string-ci-comparator
+  (make-comparator string? string-ci=? string-ci-comparison string-ci-hash))
+
+(define eq-comparator
+  (make-comparator
+    #t
+    eq?
+    #f
+    default-hash))
+
+(define eqv-comparator
+  (make-comparator
+    #t
+    eqv?
+    #f
+    default-hash))
+
+(define equal-comparator
+  (make-comparator
+    #t
+    equal?
+    #f
+    default-hash))

--- a/sets/sets-test.scm
+++ b/sets/sets-test.scm
@@ -1,5 +1,5 @@
 (use test)
-(use sets)
+(use srfi-113)
 (use srfi-128)
 
 (test-group "sets"

--- a/sets/sets-test.scm
+++ b/sets/sets-test.scm
@@ -1,6 +1,7 @@
 (use test)
 (use srfi-113)
 (use srfi-128)
+(load "../sets/comparators-shim.scm")
 
 (test-group "sets"
 (define (big x) (> x 5))
@@ -587,7 +588,7 @@
   (test-assert (not (=? bag-comparator aa bb)))
   (test-assert (=? bag-comparator aa (bag-copy aa)))
   (test-error (<? bag-comparator aa bb))
-  (test-assert (not (=? default-comparator a aa)))
+  (test-assert (not (=? (make-default-comparator) a aa)))
 ) ; end comparators
 
 ) ; end r7rs-sets

--- a/sets/sets-test.scm
+++ b/sets/sets-test.scm
@@ -1,6 +1,6 @@
 (use test)
 (use sets)
-(use comparators)
+(use srfi-128)
 
 (test-group "sets"
 (define (big x) (> x 5))

--- a/sets/sets.scm
+++ b/sets/sets.scm
@@ -1,11 +1,11 @@
 (require-library srfi-69)
-(module sets ()
+(module srfi-113 ()
   (import scheme)
   (import (only chicken
-    include define-record-type define-record-printer 
+    include define-record-type define-record-printer
     case-lambda call/cc when error use))
   (import (except srfi-69 hash-table-for-each))
-  (use comparators)
+  (use srfi-128)
 
   (export set set-unfold)
   (export set? set-contains? set-empty? set-disjoint?)
@@ -21,7 +21,7 @@
   (export set-union set-intersection set-difference set-xor
           set-union! set-intersection! set-difference! set-xor!)
   (export set-comparator)
-  
+
   (export bag bag-unfold)
   (export bag? bag-contains? bag-empty? bag-disjoint?)
   (export bag-member bag-element-comparator)
@@ -36,8 +36,8 @@
   (export bag-union bag-intersection bag-difference bag-xor
           bag-union! bag-intersection! bag-difference! bag-xor!)
   (export bag-comparator)
-  
-  
+
+
   (export bag-sum bag-sum! bag-product bag-product!
           bag-unique-size bag-element-count bag-for-each-unique bag-fold-unique
           bag-increment! bag-decrement! bag->set set->bag set->bag!

--- a/sets/sets.scm
+++ b/sets/sets.scm
@@ -43,5 +43,5 @@
           bag-increment! bag-decrement! bag->set set->bag set->bag!
           bag->alist alist->bag)
 
-  (include "sets-impl.scm")
+  (include "sets/sets-impl.scm")
 )

--- a/sets/sets.scm
+++ b/sets/sets.scm
@@ -37,7 +37,6 @@
           bag-union! bag-intersection! bag-difference! bag-xor!)
   (export bag-comparator)
 
-
   (export bag-sum bag-sum! bag-product bag-product!
           bag-unique-size bag-element-count bag-for-each-unique bag-fold-unique
           bag-increment! bag-decrement! bag->set set->bag set->bag!

--- a/srfi-113.meta
+++ b/srfi-113.meta
@@ -1,0 +1,20 @@
+;; -*- Hen -*-
+
+((egg "srfi-113.egg")
+ ; List of files that should be bundled alongside egg
+ (files "sets"
+        "tests"
+        "srfi-113.setup"
+        "srfi-113.meta"
+        "srfi-113.release-info"
+        "LICENSE")
+
+ (license "BSD")
+ (category data)
+ (depends srfi-128)
+ (test-depends test)
+ (author "John Cowan, Egg by Jeremy Steward")
+ (email "cowan@ccil.org")
+ (repo "https://github.com/scheme-requests-for-implementation/srfi-113")
+ (synopsis "Sets and Bags.")
+ (version "0.1"))

--- a/srfi-113.release-info
+++ b/srfi-113.release-info
@@ -1,0 +1,3 @@
+(repo git "git://github.com/scheme-requests-for-implementation/srfi-113.git")
+(uri targz "https://codeload.github.com/scheme-requests-for-implementation/srfi-113/tar.gz/CHICKEN-{egg-release}")
+(release "0.1")

--- a/srfi-113.setup
+++ b/srfi-113.setup
@@ -1,0 +1,9 @@
+;; -*- Hen -*-
+
+(compile -O3 -d0 -s sets/sets.scm -j srfi-113 -o srfi-113.so)
+(compile -O2 -d0 -s srfi-113.import.scm)
+
+(install-extension
+ 'srfi-113
+ '("srfi-113.so" "srfi-113.import.so")
+ '((version "0.1")))

--- a/tests/run.scm
+++ b/tests/run.scm
@@ -1,0 +1,1 @@
+(include "../sets/sets-test.scm")


### PR DESCRIPTION
This provides the legwork and files necessary to package SRFI-113 for CHICKEN Scheme, and incorporate it into an egg (CHICKEN Extension). Everything works without fail if you install locally, however as SRFI-128 is not yet packaged into an egg, the tool for testing installation (`salmonella`) will report failure. However, as I mentioned, if you install SRFI-128 locally and then call:

``` bash
$ chicken-install -s -test
```

on this repository then you'll find it installs properly, the tests all run correctly, and you can import it from the REPL or compile against it using `csc`. On that note, originally this egg was to depend on SRFI-114: Comparators, however at John Cowan's request in #chicken on Freenode, I have transitioned it to use SRFI-128: Comparators (reduced). I believe 128 supersedes 114, as the code is cleaner and has tests, whereas SRFI-114 is in a bit of a mess (in my investigation SRFI-114 had some errors in the reference implementation itself, which I can provide details for if anyone is interested, however for the most part I think people will gravitate towards SRFI-128 instead).  

NOTE: A LICENSE and README are added as well, to explain the licensing as well as what the extraneous files in the repository are if people come to visit the repo and wonder what the meta, setup, and release-info files are doing.

Lastly, if this is merged, could you please add a tag to the repo on Github so that we can include it as a CHICKEN extension? Should be as easy as:

``` bash
$ git tag 0.1
$ git push origin master --tags
```

Whether you want to annotate that tag or not is up to you (-a option for git tag).
