### PR TITLE
CHICKEN Packaging - version 0.3

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,19 @@
+Copyright (C) John Cowan (2015). All Rights Reserved.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+of the Software, and to permit persons to whom the Software is furnished to do
+so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,31 @@
+# SRFI 113 - Sets and Bags
+
+This repository hosts a reference implementation of SRFI 113 - Sets and Bags.
+The full documentation for this SRFI can be found on the [SRFI Document
+Reference](http://srfi.schemers.org/srfi-113/). The repository hosts a complete
+implementation of the SRFI, running on [CHICKEN](http://call-cc.org) Scheme.
+
+## File Description
+
+While this repository is primarily to provide a reference implementation of
+SRFI 113, it also currently serves as the base repository to host the library
+as a CHICKEN extension (egg). Thus, there are three files that are independent
+of the SRFI itself, and are as follows:
+
+`srfi-113.meta` : This file denotes metadata about the CHICKEN extension, such
+as author, license, and dependencies (and dependencies for tests).
+
+`srfi-113.setup` : This file tells the CHICKEN package manager
+(`chicken-install`) how to build the egg.
+
+`srfi-113.release-info` : Describes the URL / different releases of the CHICKEN
+extension.
+
+Additionally, the `tests/` directory has been added to accommodate the CHICKEN
+package manager (for running tests). Currently it provides a default test
+runner which merely includes the tests found in the `ilists/` directory.
+
+## License
+
+Provided under a single clause BSD license, Copyright (C) John Cowan 2015. See
+LICENSE for full details.

--- a/srfi-113.meta
+++ b/srfi-113.meta
@@ -2,8 +2,11 @@
 
 ((egg "srfi-113.egg")
  ; List of files that should be bundled alongside egg
- (files "sets"
-        "tests"
+ (files "sets/sets.scm"
+        "sets/sets-impl.scm"
+        "sets/sets-test.scm"
+        "sets/comparators-shim.scm"
+        "tests/run.scm"
         "srfi-113.setup"
         "srfi-113.meta"
         "srfi-113.release-info"
@@ -14,8 +17,8 @@
  (category data)
  (depends srfi-128)
  (test-depends test)
- (author "John Cowan, Egg by Jeremy Steward")
+ (author "John Cowan")
+ (maintainer "Jeremy Steward")
  (email "cowan@ccil.org")
  (repo "https://github.com/scheme-requests-for-implementation/srfi-113")
- (synopsis "Sets and Bags.")
- (version "0.2"))
+ (synopsis "Sets and Bags."))

--- a/srfi-113.release-info
+++ b/srfi-113.release-info
@@ -2,3 +2,4 @@
 (uri targz "https://codeload.github.com/scheme-requests-for-implementation/srfi-113/tar.gz/CHICKEN-{egg-release}")
 (release "0.1")
 (release "0.2")
+(release "0.3")

--- a/srfi-113.release-info
+++ b/srfi-113.release-info
@@ -1,5 +1,5 @@
-(uri meta-files "https://raw.githubusercontent.com/ThatGeoGuy/{egg-name}/CHICKEN-{egg-release}/{egg-name}.meta")
-(release "0.3rc2")
+(uri meta-file "https://raw.githubusercontent.com/ThatGeoGuy/{egg-name}/CHICKEN-{egg-release}/{egg-name}.meta")
+(release "0.3rc3")
 
 (repo git "git://github.com/scheme-requests-for-implementation/srfi-113.git")
 (uri targz "https://codeload.github.com/scheme-requests-for-implementation/srfi-113/tar.gz/CHICKEN-{egg-release}" whole-repo)

--- a/srfi-113.release-info
+++ b/srfi-113.release-info
@@ -1,5 +1,5 @@
 (uri meta-files "https://raw.githubusercontent.com/ThatGeoGuy/{egg-name}/CHICKEN-{egg-release}/{egg-name}.meta")
-(release "0.3rc1")
+(release "0.3rc2")
 
 (repo git "git://github.com/scheme-requests-for-implementation/srfi-113.git")
 (uri targz "https://codeload.github.com/scheme-requests-for-implementation/srfi-113/tar.gz/CHICKEN-{egg-release}" whole-repo)

--- a/srfi-113.release-info
+++ b/srfi-113.release-info
@@ -1,5 +1,4 @@
-(repo git "git://github.com/scheme-requests-for-implementation/srfi-113.git")
-(uri targz "https://codeload.github.com/scheme-requests-for-implementation/srfi-113/tar.gz/CHICKEN-{egg-release}")
+(uri meta-files "https://raw.githubusercontent.com/ThatGeoGuy/{egg-name}/CHICKEN-{egg-release}/{egg-name}.meta")
 (release "0.1")
 (release "0.2")
-(release "0.3")
+(release "0.3rc1")

--- a/srfi-113.release-info
+++ b/srfi-113.release-info
@@ -1,7 +1,8 @@
-(uri meta-file "https://raw.githubusercontent.com/ThatGeoGuy/{egg-name}/CHICKEN-{egg-release}/{egg-name}.meta")
-(release "0.3rc3")
+(uri meta-file
+     "https://raw.githubusercontent.com/scheme-requests-for-implementation/{egg-name}/CHICKEN-{egg-release}/{egg-name}.meta")
+(release "0.3")
 
 (repo git "git://github.com/scheme-requests-for-implementation/srfi-113.git")
-(uri targz "https://codeload.github.com/scheme-requests-for-implementation/srfi-113/tar.gz/CHICKEN-{egg-release}" whole-repo)
+(uri targz "https://codeload.github.com/scheme-requests-for-implementation/{egg-name}/tar.gz/CHICKEN-{egg-release}" whole-repo)
 (release "0.1" whole-repo)
 (release "0.2" whole-repo)

--- a/srfi-113.release-info
+++ b/srfi-113.release-info
@@ -1,4 +1,7 @@
 (uri meta-files "https://raw.githubusercontent.com/ThatGeoGuy/{egg-name}/CHICKEN-{egg-release}/{egg-name}.meta")
-(release "0.1")
-(release "0.2")
 (release "0.3rc1")
+
+(repo git "git://github.com/scheme-requests-for-implementation/srfi-113.git")
+(uri targz "https://codeload.github.com/scheme-requests-for-implementation/srfi-113/tar.gz/CHICKEN-{egg-release}" whole-repo)
+(release "0.1" whole-repo)
+(release "0.2" whole-repo)

--- a/srfi-113.setup
+++ b/srfi-113.setup
@@ -9,4 +9,4 @@
 (install-extension
  'srfi-113
  `(,(dynld-name "srfi-113") ,(dynld-name "srfi-113.import"))
- '((version "0.2")))
+ '((version "0.3")))


### PR DESCRIPTION
This is a quick patch to fix some issues regarding how the meta file and release-info are structured. The main problem, seen [here](https://lists.nongnu.org/archive/html/chicken-users/2016-05/msg00009.html), was that we were including more than just the files necessary to build the egg. This basically means stuff extraneous to the module itself (the HTML files, the tar.gz in the root of the repo) were getting pulled in even when users did not need them in order to install the egg. 

The files have been updated to reflect this change and now there should be no need to pull these files from Github every time a new release is made. If this is merged, could you add a tag called `CHICKEN-0.3' to the main repository?

As always, thanks for any and all assistance you can provide. I understand I've made a lot of minor changes recently, however I believe this to be the last for a while, as I've gone to a thorough extent to test everything this time.
