### PR TITLE
Bumps version to reflect README changes.

### DIFF
--- a/srfi-113.meta
+++ b/srfi-113.meta
@@ -11,7 +11,7 @@
         "srfi-113.meta"
         "srfi-113.release-info"
         "LICENSE"
-        "README.md")
+        "README.org")
 
  (license "BSD")
  (category data)

--- a/srfi-113.release-info
+++ b/srfi-113.release-info
@@ -1,5 +1,6 @@
 (uri meta-file
      "https://raw.githubusercontent.com/scheme-requests-for-implementation/{egg-name}/CHICKEN-{egg-release}/{egg-name}.meta")
+(release "0.4")
 (release "0.3")
 
 (repo git "git://github.com/scheme-requests-for-implementation/srfi-113.git")

--- a/srfi-113.setup
+++ b/srfi-113.setup
@@ -9,4 +9,4 @@
 (install-extension
  'srfi-113
  `(,(dynld-name "srfi-113") ,(dynld-name "srfi-113.import"))
- '((version "0.3")))
+ '((version "0.4")))


### PR DESCRIPTION
This should correspond to a tag for `CHICKEN-0.4`.

I merely bumped the version here to reflect the new README distributed with the SRFI.
