### PR TITLE
Removes hardcoded .so extension

### DIFF
--- a/srfi-113.release-info
+++ b/srfi-113.release-info
@@ -1,5 +1,6 @@
 (uri meta-file
      "https://raw.githubusercontent.com/scheme-requests-for-implementation/{egg-name}/CHICKEN-{egg-release}/{egg-name}.meta")
+(release "0.5")
 (release "0.4")
 (release "0.3")
 

--- a/srfi-113.setup
+++ b/srfi-113.setup
@@ -3,7 +3,7 @@
 (define (dynld-name fn)
   (make-pathname #f fn ##sys#load-dynamic-extension))
 
-(compile -O3 -d0 -s -J sets/sets.scm -o srfi-113.so)
+(compile -O3 -d0 -s -J sets/sets.scm -o ,(dynld-name "srfi-113"))
 (compile -O2 -d0 -s srfi-113.import.scm)
 
 (install-extension

--- a/srfi-113.setup
+++ b/srfi-113.setup
@@ -9,4 +9,4 @@
 (install-extension
  'srfi-113
  `(,(dynld-name "srfi-113") ,(dynld-name "srfi-113.import"))
- '((version "0.4")))
+ '((version "0.5")))


### PR DESCRIPTION
Pointed out by Mario Goulart, this hardcoded file extension could cause issues (although on my tests with Windows, did nothing).

That said, could you please tag a release `CHICKEN-0.5`? I apologize for these being so frequent, however the recent mass of work I've been doing has prompted more eyes on the code.
