### PR TITLE
Fix calls to `set-map` and `bag-map` in sets-test.scm

### DIFF
--- a/sets/sets-test.scm
+++ b/sets/sets-test.scm
@@ -46,7 +46,7 @@
   (test 2 (set-size nums))
   (set-delete! nums 1)
   (test 2 (set-size nums))
-  (set! nums2 (set-map (lambda (x) (* 10 x)) number-comparator nums))
+  (set! nums2 (set-map number-comparator (lambda (x) (* 10 x)) nums))
   ;; nums2 is now {30, 40}
   (test-assert (set-contains? nums2 30))
   (test-assert (not (set-contains? nums2 3)))
@@ -291,7 +291,7 @@
   (test 3 (bag-size nums))
   (bag-delete! nums 1)
   (test 3 (bag-size nums))
-  (set! nums2 (bag-map (lambda (x) (* 10 x)) number-comparator nums))
+  (set! nums2 (bag-map number-comparator (lambda (x) (* 10 x)) nums))
   ;; nums2 is now {20, 30, 40}
   (test-assert (bag-contains? nums2 30))
   (test-assert (not (bag-contains? nums2 3)))


### PR DESCRIPTION
Both calls incorrectly passed `comparator` as the second argument rather than the first arg.

For reference:

- http://srfi.schemers.org/srfi-113/srfi-113.html#Mappingandfolding
- https://github.com/scheme-requests-for-implementation/srfi-113/blob/master/sets/sets-impl.scm#L611