### PR TITLE
Fix pure-subset comparison, dyadic-sob<? and dyadic-sob>?

### DIFF
--- a/sets/sets-impl.scm
+++ b/sets/sets-impl.scm
@@ -853,28 +853,6 @@
           ht1))
       #t)))
 
-(define sob>?
-  (case-lambda
-    ((sob) #t)
-    ((sob1 sob2) (dyadic-sob>? sob1 sob2))
-    ((sob1 sob2 . sobs)
-     (and (dyadic-sob>? sob1 sob2)
-          (apply sob>? sob2 sobs)))))
-
-(define (set>? . sets)
-  (check-all-sets sets)
-  (apply sob>? sets))
-
-(define (bag>? . bags)
-  (check-all-bags bags)
-  (apply sob>? bags))
-
-;; > is the negation of <=.  Note that this is only true at the dyadic
-;; level; we can't just replace sob>? with a negation of sob<=?.
-
-(define (dyadic-sob>? sob1 sob2)
-  (not (dyadic-sob<=? sob1 sob2)))
-
 (define sob<?
   (case-lambda
     ((sob) #t)
@@ -891,10 +869,46 @@
   (check-all-bags bags)
   (apply sob<? bags))
 
+;; Strict subset test is a bit more involved.  At least one entry in ht1
+;; needs to have smaller value than the entry in ht2.
+(define (dyadic-sob<? sob1 sob2)
+  (call/cc
+    (lambda (return)
+      (let ((ht1 (sob-hash-table sob1))
+            (ht2 (sob-hash-table sob2)))
+        (if (not (<= (hash-table-size ht1) (hash-table-size ht2)))
+          (return #f))
+        (let ((smaller-count 0))
+          (hash-table-for-each
+           (lambda (key value)
+             (let ((value2 (hash-table-ref/default ht2 key 0)))
+               (if (not (<= value value2))
+                 (return #f)
+                 (if (< value value2)
+                   (set! smaller-count (+ smaller-count 1))))))
+           ht1)
+          (positive? smaller-count))))))
+
+(define sob>?
+  (case-lambda
+    ((sob) #t)
+    ((sob1 sob2) (dyadic-sob>? sob1 sob2))
+    ((sob1 sob2 . sobs)
+     (and (dyadic-sob>? sob1 sob2)
+          (apply sob>? sob2 sobs)))))
+
+(define (set>? . sets)
+  (check-all-sets sets)
+  (apply sob>? sets))
+
+(define (bag>? . bags)
+  (check-all-bags bags)
+  (apply sob>? bags))
+
 ;; < is the inverse of >.  Again, this is only true dyadically.
 
-(define (dyadic-sob<? sob1 sob2)
-  (dyadic-sob>? sob2 sob1))
+(define (dyadic-sob>? sob1 sob2)
+  (dyadic-sob<? sob2 sob1))
 
 (define sob>=?
   (case-lambda

--- a/sets/sets-test.scm
+++ b/sets/sets-test.scm
@@ -108,6 +108,7 @@
   (define other-set2 (set number-comparator 1 2))
   (define set3 (set number-comparator 1 2 3))
   (define set4 (set number-comparator 1 2 3 4))
+  (define sety (set number-comparator 1 2 4 5))
   (define setx (set number-comparator 10 20 30 40))
   (test-assert (set=? set2 other-set2))
   (test-assert (not (set=? set2 set3)))
@@ -120,6 +121,14 @@
   (test-assert (not (set>? set2 other-set2)))
   (test-assert (set>=? set3 other-set2 set2))
   (test-assert (not (set>=? other-set2 set3 set2)))
+  (test-assert (not (set<? set2 setx)))
+  (test-assert (not (set<=? set2 setx)))
+  (test-assert (not (set>? set2 setx)))
+  (test-assert (not (set>=? set2 setx)))
+  (test-assert (not (set<?  set3 sety)))
+  (test-assert (not (set<=? set3 sety)))
+  (test-assert (not (set>?  set3 sety)))
+  (test-assert (not (set>=? set3 sety)))
 ) ; end sets/subsets
 
 (test-group "sets/ops"
@@ -361,6 +370,7 @@
   (define bag3 (bag number-comparator 1 2 3))
   (define bag4 (bag number-comparator 1 2 3 4))
   (define bagx (bag number-comparator 10 20 30 40))
+  (define bagy (bag number-comparator 10 20 20 30 40))
   (test-assert (bag=? bag2 other-bag2))
   (test-assert (not (bag=? bag2 bag3)))
   (test-assert (not (bag=? bag2 bag3 other-bag2)))
@@ -372,6 +382,14 @@
   (test-assert (not (bag>? bag2 other-bag2)))
   (test-assert (bag>=? bag3 other-bag2 bag2))
   (test-assert (not (bag>=? other-bag2 bag3 bag2)))
+  (test-assert (bag<=? bagx bagy))
+  (test-assert (not (bag<=? bagy bagx)))
+  (test-assert (bag<? bagx bagy))
+  (test-assert (not (bag<? bagy bagx)))
+  (test-assert (bag>=? bagy bagx))
+  (test-assert (not (bag<=? bagx bagy)))
+  (test-assert (bag>? bagy bagx))
+  (test-assert (not (bag<? bagx bagy)))
 ) ; end bags/subbags
 
 (test-group "bags/multi"


### PR DESCRIPTION
Since subset relationship is not total order, <? isn't a negation
of <=?.  We need to check inclusion while explicitly detect the
case that two are equal.